### PR TITLE
Refactored State classes to share common superclass

### DIFF
--- a/arm/machine.py
+++ b/arm/machine.py
@@ -2,24 +2,22 @@
 # machine.py
 #=======================================================================
 
+from pydgin.machine import Machine
 from pydgin.storage import RegisterFile
-from pydgin.debug   import Debug, pad, pad_hex
+from pydgin.debug   import pad, pad_hex
 
 #-----------------------------------------------------------------------
 # State
 #-----------------------------------------------------------------------
-class State( object ):
+class State( Machine ):
   _virtualizable_ = ['pc', 'num_insts', 'N', 'Z', 'C', 'V']
   def __init__( self, memory, debug, reset_addr=0x400 ):
-    self.pc       = reset_addr
-    self.rf       = ArmRegisterFile( self, num_regs=16 )
-    self.mem      = memory
-
-    self    .debug = debug
-    self.rf .debug = debug
-    self.mem.debug = debug
-
-    self.rf[ 15 ]  = reset_addr
+    Machine.__init__(self,
+                     memory,
+                     ArmRegisterFile( self, num_regs=16 ),
+                     debug,
+                     reset_addr=reset_addr )
+    self.rf[ 15 ]  = self.pc
 
     # current program status register (CPSR)
     self.N    = 0b0      # Negative condition
@@ -41,16 +39,6 @@ class State( object ):
     # 0b11011     und (undefined)
     # 0b11111     sys
     self.mode = 0b10000
-
-    # other registers
-    self.status        = 0
-    self.num_insts       = 0
-    # unused
-    self.stats_en      = 0
-    self.stat_num_insts  = 0
-
-    # marks if should be running, syscall_exit sets it false
-    self.running       = True
 
     # syscall stuff... TODO: should this be here?
     self.breakpoint = 0

--- a/parc/machine.py
+++ b/parc/machine.py
@@ -2,36 +2,16 @@
 # machine.py
 #=======================================================================
 
+from pydgin.machine import Machine
 from pydgin.storage import RegisterFile
 
 #-----------------------------------------------------------------------
 # State
 #-----------------------------------------------------------------------
-class State( object ):
+class State( Machine ):
   _virtualizable_ = ['pc', 'num_insts']
-  def __init__( self, memory, debug, reset_addr=0x400 ):
-    self.pc       = reset_addr
-
-    # TODO: to allow the register file to be virtualizable (to avoid array
-    # lookups in the JIT), it needs to be an array as a member of the
-    # State class. Couldn't figure out how to have rf a RegisterFile
-    # object and still be virtualizable.
-    self.rf       = RegisterFile()
-    self.mem      = memory
-
-    self    .debug = debug
-    self.rf .debug = debug
-    self.mem.debug = debug
-
-    # coprocessor registers
-    self.status        = 0
-    self.stats_en      = 0
-    self.num_insts       = 0
-    self.stat_num_insts  = 0
-
-    # we need a dedicated running flag bacase status could be 0 on a
-    # syscall_exit
-    self.running       = True
+  def __init__( self, memory, debug, reset_addr=0x400):
+    Machine.__init__(self, memory, RegisterFile(), debug, reset_addr=reset_addr )
 
     # parc special
     self.src_ptr  = 0

--- a/pydgin/machine.py
+++ b/pydgin/machine.py
@@ -1,0 +1,30 @@
+#=======================================================================
+# machine.py
+#=======================================================================
+
+#-----------------------------------------------------------------------
+# Machine
+#-----------------------------------------------------------------------
+class Machine( object ):
+  def __init__( self, memory, register_file, debug, reset_addr=0x400 ):
+
+    self.pc       = reset_addr
+    self.rf       = register_file
+    self.mem      = memory
+
+    self    .debug = debug
+    self.rf .debug = debug
+    self.mem.debug = debug
+
+    # common registers
+    self.status        = 0
+    self.stats_en      = 0
+    self.num_insts       = 0
+    self.stat_num_insts  = 0
+
+    # we need a dedicated running flag bacase status could be 0 on a
+    # syscall_exit
+    self.running       = True
+
+  def fetch_pc( self ):
+    return self.pc


### PR DESCRIPTION
This PR is intended to resolve Issue #23 

The common parts of the `State` classes in the `parc` and `arm` simulators have been refactored. This builds successfully (with `scripts/build.py`). 