### PR TITLE
Initialised pc *after* registers, not before

### DIFF
--- a/pydgin/machine.py
+++ b/pydgin/machine.py
@@ -8,9 +8,9 @@
 class Machine( object ):
   def __init__( self, memory, register_file, debug, reset_addr=0x400 ):
 
-    self.pc       = reset_addr
     self.rf       = register_file
     self.mem      = memory
+    self.pc       = reset_addr
 
     self    .debug = debug
     self.rf .debug = debug


### PR DESCRIPTION
This is a very small change, but the Epiphany only has memory-mapped registers. This includes the program counter. To avoid getting into a mess with multicore it would be nice to model this quite faithfully, which means `Machine.pc` cannot exist before the register file has been initialised.