### PR TITLE
Exit with correct code.

### DIFF
--- a/pydgin/sim.py
+++ b/pydgin/sim.py
@@ -414,5 +414,5 @@ def init_sim( sim ):
   if caller_name == "__main__":
     # enable debug flags in interpreted mode
     Debug.global_enabled = True
-    sim.get_entry_point()( sys.argv )
+    sys.exit(sim.get_entry_point()( sys.argv ))
 


### PR DESCRIPTION
Although `entry_point` returns an integer that represents a return code, that return code never reached the OS. This PR fixes that by passing the result of `exit_code` to `sys.exit()`. 

Tested on futurecore/revelation.
